### PR TITLE
supporting 15 resource types more

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,4 @@ resource "azurerm_storage_account" "log" {
   enable_https_traffic_only = true
 }
 ```
+

--- a/README.md
+++ b/README.md
@@ -80,24 +80,37 @@ Current prototype supports:
 | App Service                         | app                         | azurerm_app_service                     |
 | Application Insights                | appi                        | azurerm_application_insights            |
 | App Service Environment             | ase                         | azurerm_app_service_environment         |
+| Application Security Group          | asg                         | azurerm_app_security_group              |
 | Azure Kubernetes Service            | aks                         | azurerm_kubernetes_cluster              |
 | Azure Kubernetes Service DNS prefix | aksdns                      | aks_dns_prefix                          |
 | AKS Node Pool Linux                 | aksnpl                      | aks_node_pool_linux                     |
 | AKS Node Pool Windows               | aksnpw                      | aks_node_pool_windows                   |
 | Azure Site Recovery                 | asr                         | azurerm_recovery_services_vault         |
+| Azure Availability Set              | avail                       | azurerm_availability_set                |
+| Azure Vpn Connection                | cn                          | azurerm_vpn_connection                  |
 | Azure Event Hubs                    | evh                         | azurerm_eventhub_namespace              |
 | generic                             | gen                         | generic                                 |
 | Azure Key Vault                     | kv                          | azurerm_key_vault                       |
 | Azure Monitor Log Analytics         | la                          | azurerm_log_analytics_workspace         |
+| Azure Load Balancer (External)      | lbe                         | azurerm_load_balancer_external          |
+| Azure Load Balancer (Internal)      | lbi                         | azurerm_load_balancer_internal          |
+| Azure Local Network Gateway         | lgw                         | azurerm_local_network_gateway           |
+| Azure Mysql Database                | mysql                       | azurerm_mysql_database                  |
 | Virtual Network Interface Card      | nic                         | azurerm_network_interface               |
 | Network Security Group              | nsg                         | azurerm_network_security_group          |
 | Public IP                           | pip                         | azurerm_public_ip                       |
 | App Service Plan                    | plan                        | azurerm_app_service_plan                |
 | Resource group                      | rg                          | azurerm_resource_group                  |
+| Azure Route Table                   | route                       | azurerm_route_table                     |
+| Azure Service Bus                   | sb                          | azurerm_service_bus                     |
+| Azure Service Bus Queue             | sbq                         | azurerm_service_bus_queue               |
+| Azure Service Bus Topic             | sbt                         | azurerm_service_bus_topic               |
 | Subnet                              | snet                        | azurerm_subnet                          |
 | Azure SQL DB Server                 | sql                         | azurerm_sql_server                      |
 | Azure SQL DB                        | sqldb                       | azurerm_sql_database                    |
 | Azure Storage Account               | st                          | azurerm_storage_account                 |
+| Azure Traffic Manager Profile       | traf                        | azurerm_traffic_manager_profile         |
+| Virtual Network Gateway             | vgw                         | azurerm_virtual_network_gateway         |
 | Linux Virtual Machine               | vml                         | azurerm_virtual_machine_linux           |
 | Windows Virtual Machine             | vmw                         | azurerm_virtual_machine_windows         |
 | Virtual Network                     | vnet                        | azurerm_virtual_network                 |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Current prototype supports:
 | Azure Traffic Manager Profile       | traf                        | azurerm_traffic_manager_profile         |
 | Virtual Network Gateway             | vgw                         | azurerm_virtual_network_gateway         |
 | Linux Virtual Machine               | vml                         | azurerm_virtual_machine_linux           |
+| Virtual Machine Scale Set Linux     | vmssl                       | azurerm_vm_scale_set_linux              |
+| Virtual Machine Scale Set Windows   | vmssw                       | azurerm_vm_scale_set_windows            |
 | Windows Virtual Machine             | vmw                         | azurerm_virtual_machine_windows         |
 | Virtual Network                     | vnet                        | azurerm_virtual_network                 |
 

--- a/azurecaf/models.go
+++ b/azurecaf/models.go
@@ -12,14 +12,16 @@ const (
 )
 
 const (
-	alphanum    string = "[^0-9A-Za-z]"
-	alphanumh   string = "[^0-9A-Za-z-]"
-	alphanumu   string = "[^0-9A-Za-z_]"
-	alphanumhu  string = "[^0-9A-Za-z_-]"
-	alphanumhup string = "[^0-9A-Za-z_.-]"
-	unicode     string = `[^-\w\._\(\)]`
-	invappi     string = "[%&\\?/]"     //appinisghts invalid character
-	invsqldb    string = "[<>*%&:\\/?]" //sql db invalid character
+	alphanum     string = "[^0-9A-Za-z]"
+	alphanumh    string = "[^0-9A-Za-z-]"
+	alphanumhp  string = "[^0-9A-Za-z\\.\\-]"
+	alphanumu    string = "[^0-9A-Za-z_]"
+	alphanumhu   string = "[^0-9A-Za-z_-]"
+	alphanumhup  string = "[^0-9A-Za-z_.-]"
+	alphanumhups string = "[^0-9A-Za-z_\\.\\-\\/]"
+	unicode      string = `[^-\w\._\(\)]`
+	invappi      string = "[%&\\?/]"     //appinisghts invalid character
+	invsqldb     string = "[<>*%&:\\/?]" //sql db invalid character
 
 	//Need to find a way to filter beginning and end of string
 	//alphanumstartletter string = "\\A[^a-z][^0-9A-Za-z]"
@@ -61,21 +63,36 @@ var Resources = map[string]ResourceStructure{
 	"app":    {"web app", "app", 2, 60, false, alphanumh, "^[0-9A-Za-z][0-9A-Za-z-]{0,58}[0-9a-zA-Z]$"},
 	"appi":   {"application insights", "appi", 1, 260, false, invappi, "^[^%&\\?/. ][^%&\\?/]{0,258}[^%&\\?/. ]$"},
 	"ase":    {"app service environment", "ase", 2, 37, false, alphanumh, "^[0-9A-Za-z-]{2,37}$"},
+	"asg":    {"application security group", "asg", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
 	"asr":    {"azure site recovery", "asr", 2, 50, false, alphanumh, "^[a-zA-Z][0-9A-Za-z-]{1,49}$"},
+	"avail":  {"availability set", "avail", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
+	"cn":     {"vpn connections", "cn", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
 	"evh":    {"event hub", "evh", 1, 50, false, alphanumh, "^[a-zA-Z][0-9A-Za-z-]{0,48}[0-9a-zA-Z]$"},
 	"gen":    {"generic", "gen", 1, 24, false, alphanum, "^[0-9a-zA-Z]{1,24}$"},
 	"kv":     {"keyvault", "kv", 3, 24, true, alphanumh, "^[a-zA-Z][0-9A-Za-z-]{0,22}[0-9a-zA-Z]$"},
 	"la":     {"loganalytics", "la", 4, 63, false, alphanumh, "^[0-9a-zA-Z][0-9A-Za-z-]{3,61}[0-9a-zA-Z]$"},
+	"lbe":    {"load balancer (external)", "lbe", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
+	"lbi":    {"load balancer (internal)", "lbi", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
+	"lgw":    {"local network gateway", "lgw", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
+	"mysql":  {"azure mysql database", "mysql", 1, 63, false, alphanumh, "^[0-9a-zA-Z-]{0,63}$"},
 	"nic":    {"network interface card", "nic", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
 	"nsg":    {"network security group", "nsg", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
 	"pip":    {"public ip address", "pip", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
 	"plan":   {"app service plan", "plan", 1, 40, false, alphanumh, "^[0-9A-Za-z-]{1,40}$"},
 	"rg":     {"resource group", "rg", 1, 80, false, unicode, `^[-\w\._\(\)]{1,80}$`},
+	"route":  {"route table", "route", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
+	"sb":     {"azure service bus", "sb", 6, 50, false, alphanumh, "^[a-zA-Z][0-9A-Za-z-]{4,48}[0-9a-zA-Z]$"},
+	"sbq":    {"azure service bus queue", "sbq", 1, 260, false, alphanumhups, "^[0-9a-zA-Z][0-9A-Za-z_\\.\\-\\/]{0,258}[0-9a-zA-Z]$"},
+	"sbt":    {"azure service bus topic", "sbt", 1, 260, false, alphanumhups, "^[0-9a-zA-Z][0-9A-Za-z_\\.\\-\\/]{0,258}[0-9a-zA-Z]$"},
 	"snet":   {"virtual network subnet", "snet", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
 	"sql":    {"azure sql db server", "sql", 1, 63, true, alphanumh, "^[0-9a-z][0-9a-z-]{0,61}[0-9a-z]$"},
 	"sqldb":  {"azure sql db", "sqldb", 1, 128, false, invsqldb, "^[^<>*%&:\\/?. ][^<>*%&:\\/?]{0,126}[^<>*%&:\\/?. ]$"},
 	"st":     {"storage account", "st", 3, 24, true, alphanum, "^[0-9a-z]{3,24}$"},
+	"traf":   {"traffic manager profile", "traf", 1, 63, false, alphanumhp, "^[0-9a-zA-Z][0-9A-Za-z\\.\\-]{0,61}[0-9a-zA-Z]$"},
+	"vgw":    {"virtual network gateway", "vgw", 1, 80, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,78}[0-9a-zA-Z_]$"},
 	"vml":    {"virtual machine (linux)", "vml", 1, 64, false, alphanumh, "^[0-9a-zA-Z][0-9A-Za-z_-]{0,62}[0-9a-zA-Z_]$"},
+	"vmssl":  {"virtual machine scale set (linux)", "vmssl", 1, 64, false, alphanumh, "^[0-9a-zA-Z][0-9A-Za-z_-]{0,62}[0-9a-zA-Z_]$"},
+	"vmssw":  {"virtual machine scale set (windows)", "vmssw", 1, 15, false, alphanumh, "^[0-9a-zA-Z][0-9A-Za-z_-]{0,13}[0-9a-zA-Z_]$"},
 	"vmw":    {"virtual machine (windows)", "vmw", 1, 15, false, alphanumh, "^[0-9a-zA-Z][0-9A-Za-z_-]{0,13}[0-9a-zA-Z_]$"},
 	"vnet":   {"virtual network", "vnet", 2, 64, false, alphanumhup, "^[0-9a-zA-Z][0-9A-Za-z_.-]{0,62}[0-9a-zA-Z_]$"},
 }
@@ -90,7 +107,10 @@ var ResourcesMapping = map[string]ResourceStructure{
 	"azurerm_app_service":                     Resources["app"],
 	"azurerm_application_insights":            Resources["appi"],
 	"azurerm_app_service_environment":         Resources["ase"],
+	"azurerm_app_security_group":              Resources["asg"],
 	"azurerm_recovery_services_vault":         Resources["asr"],
+	"azurerm_availability_set":                Resources["avail"],
+	"azurerm_vpn_connection":                  Resources["cn"],
 	"azurerm_eventhub_namespace":              Resources["evh"],
 	"generic":                                 Resources["gen"],
 	"azurerm_key_vault":                       Resources["kv"],
@@ -99,16 +119,28 @@ var ResourcesMapping = map[string]ResourceStructure{
 	"aks_node_pool_linux":                     Resources["aksnpl"],
 	"aks_node_pool_windows":                   Resources["aksnpw"],
 	"azurerm_log_analytics_workspace":         Resources["la"],
+	"azurerm_load_balancer_external":          Resources["lbe"],
+	"azurerm_load_balancer_internal":          Resources["lbi"],
+	"azurerm_local_network_gateway":           Resources["lgw"],
+	"azurerm_mysql_database":                  Resources["mysql"],
 	"azurerm_network_interface":               Resources["nic"],
 	"azurerm_network_security_group":          Resources["nsg"],
 	"azurerm_public_ip":                       Resources["pip"],
 	"azurerm_app_service_plan":                Resources["plan"],
 	"azurerm_resource_group":                  Resources["rg"],
+	"azurerm_route_table":                     Resources["route"],
+	"azurerm_service_bus":                     Resources["sb"],
+	"azurerm_service_bus_queue":               Resources["sbq"],
+	"azurerm_service_bus_topic":               Resources["sbt"],
 	"azurerm_subnet":                          Resources["snet"],
 	"azurerm_sql_server":                      Resources["sql"],
 	"azurerm_sql_database":                    Resources["sqldb"],
 	"azurerm_storage_account":                 Resources["st"],
+	"azurerm_virtual_network_gateway":         Resources["vgw"],
+	"azurerm_traffic_manager_profile":         Resources["traf"],
 	"azurerm_windows_virtual_machine_linux":   Resources["vml"],
+	"azurerm_vm_scale_set_linux":              Resources["vmssl"],
+	"azurerm_vm_scale_set_windows":            Resources["vmssw"],
 	"azurerm_windows_virtual_machine_windows": Resources["vmw"],
 	"azurerm_virtual_network":                 Resources["vnet"],
 }

--- a/azurecaf/resource_naming_convention_cafclassic_test.go
+++ b/azurecaf/resource_naming_convention_cafclassic_test.go
@@ -125,6 +125,18 @@ func TestAccCafNamingConvention_Classic(t *testing.T) {
 						11,
 						"vml"),
 					regexMatch("azurecaf_naming_convention.classic_vml", regexp.MustCompile(Resources["vml"].ValidationRegExp), 1),
+					testAccCafNamingValidation(
+						"azurecaf_naming_convention.classic_asg",
+						"AppSecGroup",
+						15,
+						"asg"),
+					regexMatch("azurecaf_naming_convention.classic_asg", regexp.MustCompile(Resources["asg"].ValidationRegExp), 1),
+					testAccCafNamingValidation(
+						"azurecaf_naming_convention.classic_cn",
+						"My_VPN_Connection_",
+						21,
+						"cn"),
+					regexMatch("azurecaf_naming_convention.classic_cn", regexp.MustCompile(Resources["cn"].ValidationRegExp), 1),
 				),
 			},
 		},
@@ -257,4 +269,19 @@ resource "azurecaf_naming_convention" "classic_vml" {
     name            = "linuxVM"
     resource_type   = "vml"
 }
+
+#Application Security Group test
+resource "azurecaf_naming_convention" "classic_asg" {
+    convention      = "cafclassic"
+    name            = "AppSecGroup"
+    resource_type   = "asg"
+}
+
+#Azure VPN Connection test
+resource "azurecaf_naming_convention" "classic_cn" {
+    convention      = "cafclassic"
+    name            = "My_VPN_Connection_"
+    resource_type   = "cn"
+}
+
 `

--- a/azurecaf/resource_naming_convention_passthrough_test.go
+++ b/azurecaf/resource_naming_convention_passthrough_test.go
@@ -95,6 +95,12 @@ func TestAccCafNamingConvention_Passthrough(t *testing.T) {
 						17,
 						"TEST"),
 					regexMatch("azurecaf_naming_convention.passthrough_sqldb", regexp.MustCompile(Resources["sqldb"].ValidationRegExp), 1),
+					testAccCafNamingValidation(
+						"azurecaf_naming_convention.passthrough_asg",
+						"TEST-DEV-APPSECGROUP-ASG",
+						24,
+						"TEST"),
+					regexMatch("azurecaf_naming_convention.passthrough_asg", regexp.MustCompile(Resources["asg"].ValidationRegExp), 1),
 				),
 			},
 		},
@@ -191,5 +197,12 @@ resource "azurecaf_naming_convention" "passthrough_sqldb" {
     convention      = "passthrough"
     name            = "TEST-DEV-SQLDB-RG"
     resource_type   = "azurerm_sql_database"
+}
+
+# Application Security Group
+resource "azurecaf_naming_convention" "passthrough_asg" {
+    convention      = "passthrough"
+    name            = "TEST-DEV-APPSECGROUP-ASG"
+    resource_type   = "azurerm_app_security_group"
 }
 `

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,24 +22,39 @@ Current prototype supports:
 | App Service                         | app                         | azurerm_app_service                     |
 | Application Insights                | appi                        | azurerm_application_insights            |
 | App Service Environment             | ase                         | azurerm_app_service_environment         |
+| Application Security Group          | asg                         | azurerm_app_security_group              |
 | Azure Kubernetes Service            | aks                         | azurerm_kubernetes_cluster              |
 | Azure Kubernetes Service DNS prefix | aksdns                      | aks_dns_prefix                          |
 | AKS Node Pool Linux                 | aksnpl                      | aks_node_pool_linux                     |
 | AKS Node Pool Windows               | aksnpw                      | aks_node_pool_windows                   |
 | Azure Site Recovery                 | asr                         | azurerm_recovery_services_vault         |
+| Azure Availability Set              | avail                       | azurerm_availability_set                |
+| Azure Vpn Connection                | cn                          | azurerm_vpn_connection                  |
 | Azure Event Hubs                    | evh                         | azurerm_eventhub_namespace              |
 | generic                             | gen                         | generic                                 |
 | Azure Key Vault                     | kv                          | azurerm_key_vault                       |
 | Azure Monitor Log Analytics         | la                          | azurerm_log_analytics_workspace         |
+| Azure Load Balancer (External)      | lbe                         | azurerm_load_balancer_external          |
+| Azure Load Balancer (Internal)      | lbi                         | azurerm_load_balancer_internal          |
+| Azure Local Network Gateway         | lgw                         | azurerm_local_network_gateway           |
+| Azure Mysql Database                | mysql                       | azurerm_mysql_database                  |
 | Virtual Network Interface Card      | nic                         | azurerm_network_interface               |
 | Network Security Group              | nsg                         | azurerm_network_security_group          |
 | Public IP                           | pip                         | azurerm_public_ip                       |
 | App Service Plan                    | plan                        | azurerm_app_service_plan                |
 | Resource group                      | rg                          | azurerm_resource_group                  |
+| Azure Route Table                   | route                       | azurerm_route_table                     |
+| Azure Service Bus                   | sb                          | azurerm_service_bus                     |
+| Azure Service Bus Queue             | sbq                         | azurerm_service_bus_queue               |
+| Azure Service Bus Topic             | sbt                         | azurerm_service_bus_topic               |
 | Subnet                              | snet                        | azurerm_subnet                          |
 | Azure SQL DB Server                 | sql                         | azurerm_sql_server                      |
 | Azure SQL DB                        | sqldb                       | azurerm_sql_database                    |
 | Azure Storage Account               | st                          | azurerm_storage_account                 |
+| Azure Traffic Manager Profile       | traf                        | azurerm_traffic_manager_profile         |
+| Virtual Network Gateway             | vgw                         | azurerm_virtual_network_gateway         |
 | Linux Virtual Machine               | vml                         | azurerm_virtual_machine_linux           |
+| Virtual Machine Scale Set Linux     | vmssl                       | azurerm_vm_scale_set_linux              |
+| Virtual Machine Scale Set Windows   | vmssw                       | azurerm_vm_scale_set_windows            |
 | Windows Virtual Machine             | vmw                         | azurerm_virtual_machine_windows         |
 | Virtual Network                     | vnet                        | azurerm_virtual_network                 |

--- a/docs/resources/azurecaf_naming_convention.md
+++ b/docs/resources/azurecaf_naming_convention.md
@@ -78,24 +78,39 @@ Current prototype supports:
 | App Service                         | app                         | azurerm_app_service                     |
 | Application Insights                | appi                        | azurerm_application_insights            |
 | App Service Environment             | ase                         | azurerm_app_service_environment         |
+| Application Security Group          | asg                         | azurerm_app_security_group              |
 | Azure Kubernetes Service            | aks                         | azurerm_kubernetes_cluster              |
 | Azure Kubernetes Service DNS prefix | aksdns                      | aks_dns_prefix                          |
 | AKS Node Pool Linux                 | aksnpl                      | aks_node_pool_linux                     |
 | AKS Node Pool Windows               | aksnpw                      | aks_node_pool_windows                   |
 | Azure Site Recovery                 | asr                         | azurerm_recovery_services_vault         |
+| Azure Availability Set              | avail                       | azurerm_availability_set                |
+| Azure Vpn Connection                | cn                          | azurerm_vpn_connection                  |
 | Azure Event Hubs                    | evh                         | azurerm_eventhub_namespace              |
 | generic                             | gen                         | generic                                 |
 | Azure Key Vault                     | kv                          | azurerm_key_vault                       |
 | Azure Monitor Log Analytics         | la                          | azurerm_log_analytics_workspace         |
+| Azure Load Balancer (External)      | lbe                         | azurerm_load_balancer_external          |
+| Azure Load Balancer (Internal)      | lbi                         | azurerm_load_balancer_internal          |
+| Azure Local Network Gateway         | lgw                         | azurerm_local_network_gateway           |
+| Azure Mysql Database                | mysql                       | azurerm_mysql_database                  |
 | Virtual Network Interface Card      | nic                         | azurerm_network_interface               |
 | Network Security Group              | nsg                         | azurerm_network_security_group          |
 | Public IP                           | pip                         | azurerm_public_ip                       |
 | App Service Plan                    | plan                        | azurerm_app_service_plan                |
 | Resource group                      | rg                          | azurerm_resource_group                  |
+| Azure Route Table                   | route                       | azurerm_route_table                     |
+| Azure Service Bus                   | sb                          | azurerm_service_bus                     |
+| Azure Service Bus Queue             | sbq                         | azurerm_service_bus_queue               |
+| Azure Service Bus Topic             | sbt                         | azurerm_service_bus_topic               |
 | Subnet                              | snet                        | azurerm_subnet                          |
 | Azure SQL DB Server                 | sql                         | azurerm_sql_server                      |
 | Azure SQL DB                        | sqldb                       | azurerm_sql_database                    |
 | Azure Storage Account               | st                          | azurerm_storage_account                 |
+| Azure Traffic Manager Profile       | traf                        | azurerm_traffic_manager_profile         |
+| Virtual Network Gateway             | vgw                         | azurerm_virtual_network_gateway         |
 | Linux Virtual Machine               | vml                         | azurerm_virtual_machine_linux           |
+| Virtual Machine Scale Set Linux     | vmssl                       | azurerm_vm_scale_set_linux              |
+| Virtual Machine Scale Set Windows   | vmssw                       | azurerm_vm_scale_set_windows            |
 | Windows Virtual Machine             | vmw                         | azurerm_virtual_machine_windows         |
 | Virtual Network                     | vnet                        | azurerm_virtual_network                 |

--- a/examples/cafclassic.tf
+++ b/examples/cafclassic.tf
@@ -273,3 +273,257 @@ output "vml_classic" {
   description = "Random result based on the resource type"
 }
 
+#Application Security Group test
+resource "azurecaf_naming_convention" "classic_asg" {
+    convention      = "cafclassic"
+    name            = "AppSecGroup"
+    resource_type   = "asg"
+}
+
+output "asg_classic_id" {
+  value       = azurecaf_naming_convention.classic_asg.id
+  description = "Id of the resource's name"
+}
+
+output "asg_classic" {
+  value       = azurecaf_naming_convention.classic_asg.result
+  description = "Random result based on the resource type"
+}
+
+#Azure VPN Connection
+resource "azurecaf_naming_convention" "classic_cn" {
+    convention      = "cafclassic"
+    name            = "My_VPN_Connection_"
+    resource_type   = "cn"
+}
+
+output "cn_classic_id" {
+  value       = azurecaf_naming_convention.classic_cn.id
+  description = "Id of the resource's name"
+}
+
+output "cn_classic" {
+  value       = azurecaf_naming_convention.classic_cn.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Load Balancer (external)
+resource "azurecaf_naming_convention" "classic_lbe" {
+    convention      = "cafclassic"
+    name            = "My_External.Load.Balancer_"
+    resource_type   = "lbe"
+}
+
+output "lbe_classic_id" {
+  value       = azurecaf_naming_convention.classic_lbe.id
+  description = "Id of the resource's name"
+}
+
+output "lbe_classic" {
+  value       = azurecaf_naming_convention.classic_lbe.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Load Balancer (internal)
+resource "azurecaf_naming_convention" "classic_lbi" {
+    convention      = "cafclassic"
+    name            = "My_Internal.Load.Balancer_"
+    resource_type   = "lbi"
+}
+
+output "lbi_classic_id" {
+  value       = azurecaf_naming_convention.classic_lbi.id
+  description = "Id of the resource's name"
+}
+
+output "lbi_classic" {
+  value       = azurecaf_naming_convention.classic_lbi.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Local Network Gateway
+resource "azurecaf_naming_convention" "classic_lgw" {
+    convention      = "cafclassic"
+    name            = "My_Local.Network.Gateway_"
+    resource_type   = "lgw"
+}
+
+output "lgw_classic_id" {
+  value       = azurecaf_naming_convention.classic_lgw.id
+  description = "Id of the resource's name"
+}
+
+output "lgw_classic" {
+  value       = azurecaf_naming_convention.classic_lgw.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Mysql Database
+resource "azurecaf_naming_convention" "classic_mysql" {
+    convention      = "cafclassic"
+    name            = "My-MySQL-Database-001"
+    resource_type   = "mysql"
+}
+
+output "mysql_classic_id" {
+  value       = azurecaf_naming_convention.classic_mysql.id
+  description = "Id of the resource's name"
+}
+
+output "mysql_classic" {
+  value       = azurecaf_naming_convention.classic_mysql.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Route Table
+resource "azurecaf_naming_convention" "classic_route" {
+    convention      = "cafclassic"
+    name            = "My-Route.Table-001_"
+    resource_type   = "route"
+}
+
+output "route_classic_id" {
+  value       = azurecaf_naming_convention.classic_route.id
+  description = "Id of the resource's name"
+}
+
+output "route_classic" {
+  value       = azurecaf_naming_convention.classic_route.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Service Bus
+resource "azurecaf_naming_convention" "classic_sb" {
+    convention      = "cafclassic"
+    name            = "My-Service.Bus-001_"
+    resource_type   = "sb"
+}
+
+output "sb_classic_id" {
+  value       = azurecaf_naming_convention.classic_sb.id
+  description = "Id of the resource's name"
+}
+
+output "sb_classic" {
+  value       = azurecaf_naming_convention.classic_sb.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Service queue
+resource "azurecaf_naming_convention" "classic_sbq" {
+    convention      = "cafclassic"
+    name            = "My-Service.Bus/001/queue/001"
+    resource_type   = "sbq"
+}
+
+output "sbq_classic_id" {
+  value       = azurecaf_naming_convention.classic_sbq.id
+  description = "Id of the resource's name"
+}
+
+output "sbq_classic" {
+  value       = azurecaf_naming_convention.classic_sbq.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Service Topic
+resource "azurecaf_naming_convention" "classic_sbt" {
+    convention      = "cafclassic"
+    name            = "My-Service.Bus/001/queue/001/topic/001"
+    resource_type   = "sbt"
+}
+
+output "sbt_classic_id" {
+  value       = azurecaf_naming_convention.classic_sbt.id
+  description = "Id of the resource's name"
+}
+
+output "sbt_classic" {
+  value       = azurecaf_naming_convention.classic_sbt.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Virtual Network Gateway
+resource "azurecaf_naming_convention" "classic_vgw" {
+    convention      = "cafclassic"
+    name            = "My-Virtual.Network.Gateway-001_"
+    resource_type   = "vgw"
+}
+
+output "vgw_classic_id" {
+  value       = azurecaf_naming_convention.classic_vgw.id
+  description = "Id of the resource's name"
+}
+
+output "vgw_classic" {
+  value       = azurecaf_naming_convention.classic_vgw.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Availability Set
+resource "azurecaf_naming_convention" "classic_avail" {
+    convention      = "cafclassic"
+    name            = "My-AvailabilitySet-001_"
+    resource_type   = "avail"
+}
+
+output "avail_classic_id" {
+  value       = azurecaf_naming_convention.classic_avail.id
+  description = "Id of the resource's name"
+}
+
+output "avail_classic" {
+  value       = azurecaf_naming_convention.classic_avail.result
+  description = "Random result based on the resource type"
+}
+
+#Azure Traffic Manager Profile
+resource "azurecaf_naming_convention" "classic_traf" {
+    convention      = "cafclassic"
+    name            = "My-Traffic.Manager-001_"
+    resource_type   = "traf"
+}
+
+output "traf_classic_id" {
+  value       = azurecaf_naming_convention.classic_traf.id
+  description = "Id of the resource's name"
+}
+
+output "traf_classic" {
+  value       = azurecaf_naming_convention.classic_traf.result
+  description = "Random result based on the resource type"
+}
+
+#Azure VM Scale Set Linux
+resource "azurecaf_naming_convention" "classic_vmssl" {
+    convention      = "cafclassic"
+    name            = "My-VM-ScaleSet-001_"
+    resource_type   = "vmssl"
+}
+
+output "vmssl_classic_id" {
+  value       = azurecaf_naming_convention.classic_vmssl.id
+  description = "Id of the resource's name"
+}
+
+output "vmssl_classic" {
+  value       = azurecaf_naming_convention.classic_vmssl.result
+  description = "Random result based on the resource type"
+}
+
+#Azure VM Scale Set Windows
+resource "azurecaf_naming_convention" "classic_vmssw" {
+    convention      = "cafclassic"
+    name            = "VMScaleSet001"
+    resource_type   = "vmssw"
+}
+
+output "vmssw_classic_id" {
+  value       = azurecaf_naming_convention.classic_vmssw.id
+  description = "Id of the resource's name"
+}
+
+output "vmssw_classic" {
+  value       = azurecaf_naming_convention.classic_vmssw.result
+  description = "Random result based on the resource type"
+}


### PR DESCRIPTION
Hello,
here you will find a PR to add support to the following resource types (based on CAF Naming convention, and compliant with rules and restrictions from Azure) :
- Application Security Group
- Azure Availability Set
- Azure Vpn Connection
- Azure Load Balancer (External)
- Azure Load Balancer (Internal)
- Azure Local Network Gateway
- Azure Mysql Database
- Azure Route Table
- Azure Service Bus
- Azure Service Bus Queue
- Azure Service Bus Topic
- Azure Traffic Manager Profile
- Virtual Network Gateway
- Virtual Machine Scale Set Linux
- Virtual Machine Scale Set Windows

hope it helps !
Best regards.