### PR TITLE
allow name precedence to be specified

### DIFF
--- a/azurecaf/resource_name_test.go
+++ b/azurecaf/resource_name_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+var DefaultNamePrecedence = []string{"slug", "name", "random", "suffixes", "prefixes"}
+
 func setData(prefixes []string, name string, suffixes []string, cleanInput bool) *schema.ResourceData {
 	data := &schema.ResourceData{}
 	data.Set("name", name)
@@ -158,7 +160,7 @@ func TestAccResourceNameRsv_CafClassic(t *testing.T) {
 }
 
 func TestComposeName(t *testing.T) {
-	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
+	namePrecedence := DefaultNamePrecedence
 	prefixes := []string{"a", "b"}
 	suffixes := []string{"c", "d"}
 	name := composeName("-", prefixes, "name", "slug", suffixes, "rd", 21, namePrecedence)
@@ -169,8 +171,20 @@ func TestComposeName(t *testing.T) {
 	}
 }
 
+func TestComposeNameWithPrecedence(t *testing.T) {
+	namePrecedence := []string{"random", "name", "slug", "suffixes", "prefixes"}
+	prefixes := []string{"a", "b"}
+	suffixes := []string{"c", "d"}
+	name := composeName("-", prefixes, "name", "slug", suffixes, "rd", 21, namePrecedence)
+	expected := "a-b-rd-name-slug-c-d"
+	if name != expected {
+		t.Logf("Fail to generate name expected %s received %s", expected, name)
+		t.Fail()
+	}
+}
+
 func TestComposeNameCutCorrect(t *testing.T) {
-	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
+	namePrecedence := DefaultNamePrecedence
 	prefixes := []string{"a", "b"}
 	suffixes := []string{"c", "d"}
 	name := composeName("-", prefixes, "name", "slug", suffixes, "rd", 20, namePrecedence)
@@ -182,7 +196,7 @@ func TestComposeNameCutCorrect(t *testing.T) {
 }
 
 func TestComposeNameCutCorrectSuffixes(t *testing.T) {
-	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
+	namePrecedence := DefaultNamePrecedence
 	prefixes := []string{"a", "b"}
 	suffixes := []string{"c", "d"}
 	name := composeName("-", prefixes, "name", "slug", suffixes, "rd", 15, namePrecedence)
@@ -194,7 +208,7 @@ func TestComposeNameCutCorrectSuffixes(t *testing.T) {
 }
 
 func TestComposeEmptyStringArray(t *testing.T) {
-	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
+	namePrecedence := DefaultNamePrecedence
 	prefixes := []string{"", "b"}
 	suffixes := []string{"", "d"}
 	name := composeName("-", prefixes, "", "", suffixes, "", 15, namePrecedence)
@@ -233,7 +247,7 @@ func TestValidResourceType_invalidParameters(t *testing.T) {
 }
 
 func TestGetResourceNameValid(t *testing.T) {
-	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
+	namePrecedence := DefaultNamePrecedence
 	resourceName, err := getResourceName("azurerm_resource_group", "-", []string{"a", "b"}, "myrg", nil, "1234", "cafclassic", true, false, true, namePrecedence)
 	expected := "a-b-rg-myrg-1234"
 
@@ -248,7 +262,7 @@ func TestGetResourceNameValid(t *testing.T) {
 }
 
 func TestGetResourceNameValidRsv(t *testing.T) {
-	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
+	namePrecedence := DefaultNamePrecedence
 	resourceName, err := getResourceName("azurerm_recovery_services_vault", "-", []string{"a", "b"}, "test", nil, "1234", "cafclassic", true, false, true, namePrecedence)
 	expected := "a-b-rsv-test-1234"
 
@@ -263,7 +277,7 @@ func TestGetResourceNameValidRsv(t *testing.T) {
 }
 
 func TestGetResourceNameValidNoSlug(t *testing.T) {
-	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
+	namePrecedence := DefaultNamePrecedence
 	resourceName, err := getResourceName("azurerm_resource_group", "-", []string{"a", "b"}, "myrg", nil, "1234", "cafclassic", true, false, false, namePrecedence)
 	expected := "a-b-myrg-1234"
 
@@ -278,7 +292,7 @@ func TestGetResourceNameValidNoSlug(t *testing.T) {
 }
 
 func TestGetResourceNameInvalidResourceType(t *testing.T) {
-	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
+	namePrecedence := DefaultNamePrecedence
 	resourceName, err := getResourceName("azurerm_invalid", "-", []string{"a", "b"}, "myrg", nil, "1234", "cafclassic", true, false, true, namePrecedence)
 	expected := "a-b-rg-myrg-1234"
 
@@ -293,7 +307,7 @@ func TestGetResourceNameInvalidResourceType(t *testing.T) {
 }
 
 func TestGetResourceNamePassthrough(t *testing.T) {
-	namePrecedence := []string{"name", "slug", "random", "suffixes", "prefixes"}
+	namePrecedence := DefaultNamePrecedence
 	resourceName, _ := getResourceName("azurerm_resource_group", "-", []string{"a", "b"}, "myrg", nil, "1234", "cafclassic", true, true, true, namePrecedence)
 	expected := "myrg"
 

--- a/docs/resources/azurecaf_name.md
+++ b/docs/resources/azurecaf_name.md
@@ -45,6 +45,7 @@ The following arguments are supported:
 * **name** - (optional) the basename of the resource to create, the basename will be sanitized as per supported characters set for each Azure resources.
 * **prefixes** (optional) - a list of prefix to append as the first characters of the generated name - prefixes will be separated by the separator character
 * **suffixes** (optional) -  a list of additional suffix added after the basename, this is can be used to append resource index (eg. vm-001). Suffixes are separated by the separator character
+* **name_precedence** (optional) - a list specifying the order of the segments used to generate the name.  Must be some combination of `name`, `slug` and `random` without duplicates.  Defaults to `[slug, name, random]`.
 * **random_length** (optional) - default to ``0`` : configure additional characters to append to the generated resource name. Random characters will remain compliant with the set of allowed characters per resources and will be appended after the suffixes
 * **random_seed** (optional) - default to ``0`` : Define the seed to be used for random generator. 0 will not be respected and will generate a seed based in the unix time of the generation.
 * **resource_type** (optional) -  describes the type of azure resource you are requesting a name from (eg. azure container registry: azurerm_container_registry). See the Resource Type section

--- a/docs/resources/azurecaf_name.md
+++ b/docs/resources/azurecaf_name.md
@@ -45,7 +45,7 @@ The following arguments are supported:
 * **name** - (optional) the basename of the resource to create, the basename will be sanitized as per supported characters set for each Azure resources.
 * **prefixes** (optional) - a list of prefix to append as the first characters of the generated name - prefixes will be separated by the separator character
 * **suffixes** (optional) -  a list of additional suffix added after the basename, this is can be used to append resource index (eg. vm-001). Suffixes are separated by the separator character
-* **name_precedence** (optional) - a list specifying the order of the segments used to generate the name.  Must be some combination of `name`, `slug` and `random` without duplicates.  Defaults to `[slug, name, random]`.
+* **name_precedence** (optional) - a list specifying the order of the segments used to generate the name.  Must be some combination of `name`, `slug` and `random` without duplicates.  Defaults to `["slug", "name", "random"]`.
 * **random_length** (optional) - default to ``0`` : configure additional characters to append to the generated resource name. Random characters will remain compliant with the set of allowed characters per resources and will be appended after the suffixes
 * **random_seed** (optional) - default to ``0`` : Define the seed to be used for random generator. 0 will not be respected and will generate a seed based in the unix time of the generation.
 * **resource_type** (optional) -  describes the type of azure resource you are requesting a name from (eg. azure container registry: azurerm_container_registry). See the Resource Type section


### PR DESCRIPTION
This PR is to allow someone who is consuming the component to specify the order of the three sections of the name (not including prefix/suffix, which, by their name should always be at the beginning or end).  Our use case is that we potentially wanted the ability to put the slug at the end precedence of `["name","random","slug"]` with `suffixes = []`.  The restrictions I've placed on the `name_precedence` require it to be a list of three unique strings, where each string must be one of `name`, `random` or `slug`.

 This included changing a line in the `composeName` function but will result in no change to any current functionality as I did not find any cases of the `initialized` function arg being set.

All unit tests passed, and I have added a new one to test the name order swap.