### PR TITLE
fix(resourceDefinition.json) allow underscores within azurerm_key_vault_secret

### DIFF
--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -1549,7 +1549,7 @@
         "name": "azurerm_key_vault_secret",
         "min_length": 1,
         "max_length": 127,
-        "validation_regex": "\"^[a-zA-Z0-9-]{1,127}$\"",
+        "validation_regex": "\"^[a-zA-Z0-9-_]{1,127}$\"",
         "scope": "parent",
         "slug": "kvs",
         "dashes": true,


### PR DESCRIPTION
## Issue

### Unable to create Postgres flexible server databases with underscore [950](https://github.com/aztfmod/terraform-azurerm-caf/issues/950)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have read the [CONTRIBUTING.MD instructions](./CONTRIBUTING.md)
- [x] I have changed the `resourceDefinition.json`
- [ ] I have generated the resource model (there's a ```models_generated.go``` file in my PR)
- [ ] I have updated the [README.md#resource-status](../README.md)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
allow underscores within azurerm_key_vault_secret

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Testing

Needs testing
