### PR TITLE
Add support for updates to resource type(s)

### DIFF
--- a/azurecaf/models.go
+++ b/azurecaf/models.go
@@ -60,6 +60,10 @@ var (
 	alphagenerator = []rune("abcdefghijklmnopqrstuvwxyz")
 )
 
+func randomSeed() int64 {
+	return time.Now().UnixNano()
+}
+
 // Generate a random value to add to the resource names
 func randSeq(length int, seed *int64) string {
 	if length == 0 {
@@ -67,7 +71,7 @@ func randSeq(length int, seed *int64) string {
 	}
 	// initialize random seed
 	if seed == nil || *seed == 0 {
-		value := time.Now().UnixNano()
+		value := randomSeed()
 		seed = &value
 	}
 	rand.Seed(*seed)

--- a/azurecaf/resource_name_test.go
+++ b/azurecaf/resource_name_test.go
@@ -150,6 +150,34 @@ func TestAccResourceName_CafClassic(t *testing.T) {
 	})
 }
 
+func TestAccResourceName_ChangeResourceTypes(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNameSingleResourceType,
+				Check: resource.ComposeTestCheckFunc(
+					regexMatch("azurecaf_name.test", regexp.MustCompile(ResourceDefinitions["azurerm_resource_group"].ValidationRegExp), 1),
+					resource.TestCheckResourceAttr("azurecaf_name.test", "results.%", "0"),
+				),
+			},
+			{
+				Config: testAccResourceNameMultipleResourceType,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("azurecaf_name.test", "result", ""),
+					resource.TestCheckResourceAttr("azurecaf_name.test", "results.%", "4"),
+					resource.TestMatchResourceAttr("azurecaf_name.test", "results.azurerm_resource_group", regexp.MustCompile(ResourceDefinitions["azurerm_resource_group"].ValidationRegExp)),
+					resource.TestMatchResourceAttr("azurecaf_name.test", "results.azurerm_recovery_services_vault", regexp.MustCompile(ResourceDefinitions["azurerm_recovery_services_vault"].ValidationRegExp)),
+					resource.TestMatchResourceAttr("azurecaf_name.test", "results.azurerm_api_management_service", regexp.MustCompile(ResourceDefinitions["azurerm_api_management_service"].ValidationRegExp)),
+					resource.TestMatchResourceAttr("azurecaf_name.test", "results.azurerm_container_registry", regexp.MustCompile(ResourceDefinitions["azurerm_container_registry"].ValidationRegExp)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceName_CafClassicRSV(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -394,7 +422,7 @@ resource "azurecaf_name" "apim" {
 	random_length = 0
 	clean_input = true
 	passthrough = false
-   }
+}
 `
 
 const testAccResourceNameCafClassicConfigRsv = `
@@ -411,5 +439,29 @@ resource "azurecaf_name" "rsv" {
 	random_seed     = 1
 	clean_input     = true
 	passthrough     = false
+}
+`
+
+const testAccResourceNameMultipleResourceType = `
+resource "azurecaf_name" "test" {
+    name            = "test"
+	resource_types  = ["azurerm_resource_group", "azurerm_recovery_services_vault", "azurerm_api_management_service", "azurerm_container_registry"]
+	prefixes        = ["pr1", "pr2"]
+	suffixes        = ["su1", "su2"]
+	random_seed     = 1
+	random_length   = 5
+	clean_input     = true
+}
+`
+
+const testAccResourceNameSingleResourceType = `
+resource "azurecaf_name" "test" {
+    name            = "test"
+	resource_type   = "azurerm_resource_group"
+	prefixes        = ["pr1", "pr2"]
+	suffixes        = ["su1", "su2"]
+	random_seed     = 1
+	random_length   = 5
+	clean_input     = true
 }
 `


### PR DESCRIPTION
Signed-off-by: Owen Farrell <owen.farrell@gmail.com>

Fixes #140 

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have read the [CONTRIBUTING.MD instructions](./CONTRIBUTING.md)
- [ ] I have changed the `resourceDefinition.json`
- [ ] I have generated the resource model (there's a ```models_generated.go``` file in my PR)
- [ ] I have updated the [README.md#resource-status](../README.md)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

While this doesn't inherently introduce a backwards-breaking change, I don't see a way to support auto-upgrades of the current version of the provider to support this change. Anyone who attempts to auto-upgrade will incur the existing behavior (a forced deletion/recreation of downstream resources) one more time. Any suggestions on how to mitigate this issue would be appreciated.

## Testing

In addition to local unit testing, I've exercised these updates via a local provider override and it seems to meet the need.

```
$ make build
go generate

2022/10/13 15:40:19 File generated
go fmt ./...
azurecaf/models_generated.go
azurecaf/provider_test.go
go build -o ./terraform-provider-azurecaf
go test ./...
?       github.com/aztfmod/terraform-provider-azurecaf  [no test files]
ok      github.com/aztfmod/terraform-provider-azurecaf/azurecaf 22.411s
?       github.com/aztfmod/terraform-provider-azurecaf/completness      [no test files]
```