### PR TITLE
Deprecate azurecaf_naming_convention resource in favor of azurecaf_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ terraform {
 }
 ```
 
+## Important Notice
+
+> :warning: **Deprecation Notice**: The `azurecaf_naming_convention` resource is deprecated. Please use `azurecaf_name` instead, which provides more flexibility and supports a broader range of Azure resources. See the [migration guide](./docs/resources/azurecaf_naming_convention.md#migration-to-azurecaf_name) for details on how to migrate your configurations.
+
 The azurecaf_name resource allows you to:
 
 * Clean inputs to make sure they remain compliant with the allowed patterns for each Azure resource.

--- a/azurecaf/resource_naming_convention.go
+++ b/azurecaf/resource_naming_convention.go
@@ -21,10 +21,11 @@ func resourceNamingConvention() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Create:        resourceNamingConventionCreate,
-		Read:          schema.Noop,
-		Delete:        schema.RemoveFromState,
-		SchemaVersion: 2,
+		Create:             resourceNamingConventionCreate,
+		Read:               schema.Noop,
+		Delete:             schema.RemoveFromState,
+		SchemaVersion:      2,
+		DeprecationMessage: "The azurecaf_naming_convention resource is deprecated. Please use azurecaf_name instead, which provides more flexibility and supports a broader range of Azure resources.",
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurecaf/resource_naming_convention.go
+++ b/azurecaf/resource_naming_convention.go
@@ -25,7 +25,7 @@ func resourceNamingConvention() *schema.Resource {
 		Read:               schema.Noop,
 		Delete:             schema.RemoveFromState,
 		SchemaVersion:      2,
-		DeprecationMessage: "The azurecaf_naming_convention resource is deprecated. Please use azurecaf_name instead, which provides more flexibility and supports a broader range of Azure resources.",
+		DeprecationMessage: DeprecationMessage,
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurecaf/resource_naming_convention_deprecation_test.go
+++ b/azurecaf/resource_naming_convention_deprecation_test.go
@@ -1,0 +1,19 @@
+package azurecaf
+
+import (
+	"testing"
+)
+
+func TestNamingConventionDeprecation(t *testing.T) {
+	provider := Provider()
+	resource := provider.ResourcesMap["azurecaf_naming_convention"]
+
+	if resource.DeprecationMessage == "" {
+		t.Error("azurecaf_naming_convention should have a deprecation message")
+	}
+
+	expectedMessage := "The azurecaf_naming_convention resource is deprecated. Please use azurecaf_name instead, which provides more flexibility and supports a broader range of Azure resources."
+	if resource.DeprecationMessage != expectedMessage {
+		t.Errorf("Expected deprecation message '%s', got '%s'", expectedMessage, resource.DeprecationMessage)
+	}
+}

--- a/docs/resources/azurecaf_naming_convention.md
+++ b/docs/resources/azurecaf_naming_convention.md
@@ -1,5 +1,7 @@
 # azurecaf_naming_convention
 
+!> **WARNING:** This resource is deprecated. Please use [`azurecaf_name`](azurecaf_name.md) instead, which provides more flexibility and supports a broader range of Azure resources.
+
 The resource naming_convention implements a set of methodologies to apply consistent resource naming using the default Microsoft Cloud Adoption Framework for Azure recommendations as per https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging.
 
 The naming_convention is the initial resource released as part of the azurecaf provider, the naming_convention supports a fixed set of resources as described in the documention. In order to provider more flexibility and support the large breadth of Azure resources available you can use the azurecaf_name resource.
@@ -63,6 +65,46 @@ The following methods are implemented for naming conventions:
 | cafrandom | follows Cloud Adoption Framework for Azure recommendations as per https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging and adds randomly generated characters up to maximum length of name |
 | random | name will be generated automatically in full lengths of azure object |
 | passthrough | naming convention is implemented manually, fields given as input will be same as the output (but lengths and forbidden chars will be filtered out) |
+
+## Migration to azurecaf_name
+
+To migrate from `azurecaf_naming_convention` to `azurecaf_name`, you need to update your configuration. Here's how the parameters map between the old and new resources:
+
+### Parameter Mapping
+
+| azurecaf_naming_convention | azurecaf_name | Notes |
+|----------------------------|---------------|-------|
+| `name` | `name` | Same parameter |
+| `prefix` | `prefixes` | Single string becomes a list |
+| `postfix` | `suffixes` | Single string becomes a list |
+| `resource_type` | `resource_type` | Use the azurerm resource type (see mapping table below) |
+| `convention` | N/A | Replaced by other parameters: use `random_length` for random characters |
+| `max_length` | `resource_types` | Length validation is automatic based on resource type |
+
+### Migration Example
+
+**Old configuration:**
+```hcl
+resource "azurecaf_naming_convention" "cafrandom_rg" {  
+  name          = "aztfmod"
+  prefix        = "dev"
+  resource_type = "rg"
+  postfix       = "001"
+  max_length    = 23
+  convention    = "cafrandom"
+}
+```
+
+**New configuration:**
+```hcl
+resource "azurecaf_name" "rg_example" {
+  name          = "aztfmod"
+  prefixes      = ["dev"]
+  resource_type = "azurerm_resource_group"
+  suffixes      = ["001"]
+  random_length = 5  # If you want random characters
+}
+```
 
 ## Resource types
 


### PR DESCRIPTION
This pull request introduces a deprecation of the `azurecaf_naming_convention` resource, replacing it with the more flexible `azurecaf_name` resource. Key changes include documentation updates, code modifications to mark the resource as deprecated, and the addition of a migration guide to assist users in transitioning to the new resource.

### Deprecation Notice and Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22-R25): Added a deprecation notice for `azurecaf_naming_convention` and provided a link to the migration guide for transitioning to `azurecaf_name`.
* [`docs/resources/azurecaf_naming_convention.md`](diffhunk://#diff-145f3397397d3c0427955dcf311dc0458c1d912c1aefd0ca4ced180869f6fac4R3-R4): Added a warning about the deprecation, detailed parameter mappings, and provided an example for migrating configurations to `azurecaf_name`. [[1]](diffhunk://#diff-145f3397397d3c0427955dcf311dc0458c1d912c1aefd0ca4ced180869f6fac4R3-R4) [[2]](diffhunk://#diff-145f3397397d3c0427955dcf311dc0458c1d912c1aefd0ca4ced180869f6fac4R69-R108)

### Code Changes:
* [`azurecaf/resource_naming_convention.go`](diffhunk://#diff-5d4bd982bc9c0154d949d933b2889e4a5cae13feb4d2cd6d1c329beecaa74501R28): Added a `DeprecationMessage` to the schema for the `azurecaf_naming_convention` resource, informing users of its deprecation.

### Testing:
* [`azurecaf/resource_naming_convention_deprecation_test.go`](diffhunk://#diff-eb2ec56a2be6014be4b62581656098a5c958f8f9666eebacdfab5554a2afbe2dR1-R19): Introduced a new test to ensure the `DeprecationMessage` for `azurecaf_naming_convention` is correctly set and matches the expected message.