### PR TITLE
fix: Release provider as zip archives not tarballs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,8 @@ builds:
         goarch: arm64
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256


### PR DESCRIPTION
The Archive format configuration has benn removed in https://github.com/aztfmod/terraform-provider-azurecaf/commit/99cfadcd5856541ef619560cc374ce9291ff51d1\#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L31

# [Issue-id](https://github.com/aztfmod/terraform-provider-azurecaf/issues/343)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have read the [CONTRIBUTING.MD instructions](./CONTRIBUTING.md)
- [ ] I have changed the `resourceDefinition.json`
- [ ] I have generated the resource model (there's a ```models_generated.go``` file in my PR)
- [ ] I have updated the [README.md#resource-status](../README.md)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

During the migration from GoReleaser v1 to v2, the output archive format configuration has been removed and causing the release pipeline to publish provider in tar.gz format, which is not compatible with Terraform, causing following error during `terraform install`:

```text
│ Error: Failed to install provider
│ 
│ Error while installing aztfmod/azurecaf v1.2.30: zip: not a valid zip file
```

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

The output of the GoReleaser will be published as `zip`, instead of GoReleaser default `tar.gz`