### PR TITLE
ci: align Go toolchain across env + SHA-pin hand-authored workflows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
         "ghcr.io/azure/azure-dev/azd:latest": {},
         "ghcr.io/devcontainers/features/azure-cli:1": {},
         "ghcr.io/devcontainers/features/go:1": {
-            "version": "1.24.4"
+            "version": "1.25.0"
         },
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainers/features/terraform:1": {},

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -207,7 +207,7 @@ Add your resource definition to the JSON file:
 
 ### Prerequisites
 
-- **Go 1.24.4+**: [Download Go](https://golang.org/dl/)
+- **Go 1.25.0+**: [Download Go](https://golang.org/dl/)
 - **Terraform 1.0+**: [Download Terraform](https://www.terraform.io/downloads.html)
 - **Make**: For running build commands
 - **Git**: For version control

--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -4,6 +4,11 @@
       "repo": "actions/github-script",
       "version": "v9.0.0",
       "sha": "3a2844b7e9c422d3c10d287c895573f7108da1b3"
+    },
+    "actions/setup-go@v6": {
+      "repo": "actions/setup-go",
+      "version": "v6",
+      "sha": "4a3601121dd01d1626a1e23e37211e3254c1c06c"
     }
   }
 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,10 +26,10 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: './go.mod'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,10 +37,10 @@ jobs:
     
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: './go.mod'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,12 +22,12 @@ jobs:
       id-token: write  # Required for keyless signing
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: './go.mod'
 

--- a/.github/workflows/pr-review-agent.lock.yml
+++ b/.github/workflows/pr-review-agent.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7e96671f571670285deaf257d5094757ab776366fb382c66d42515eae3e46095","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"v0.72.1","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"937f8a801f601e926361ad08e6d47083d1c73cdfd0140f8b55b312115c9e6c77","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"v0.72.1","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -39,6 +39,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+#   - actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@v0.72.1
@@ -203,20 +204,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a1981d8eaf9ff4a5_EOF'
+          cat << 'GH_AW_PROMPT_62af5a31c6cd1e44_EOF'
           <system>
-          GH_AW_PROMPT_a1981d8eaf9ff4a5_EOF
+          GH_AW_PROMPT_62af5a31c6cd1e44_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a1981d8eaf9ff4a5_EOF'
+          cat << 'GH_AW_PROMPT_62af5a31c6cd1e44_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_a1981d8eaf9ff4a5_EOF
+          GH_AW_PROMPT_62af5a31c6cd1e44_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a1981d8eaf9ff4a5_EOF'
+          cat << 'GH_AW_PROMPT_62af5a31c6cd1e44_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -245,12 +246,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a1981d8eaf9ff4a5_EOF
+          GH_AW_PROMPT_62af5a31c6cd1e44_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a1981d8eaf9ff4a5_EOF'
+          cat << 'GH_AW_PROMPT_62af5a31c6cd1e44_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-review-agent.md}}
-          GH_AW_PROMPT_a1981d8eaf9ff4a5_EOF
+          GH_AW_PROMPT_62af5a31c6cd1e44_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -382,6 +383,16 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          cache: true
+          go-version-file: ./go.mod
+      - continue-on-error: true
+        id: build
+        name: Build provider
+        run: "set -o pipefail\nif make build 2>&1 | tee /tmp/pr-build.log; then\n  echo \"BUILD_RESULT=pass\" > /tmp/pr-review-results.env\nelse\n  echo \"BUILD_RESULT=fail\" > /tmp/pr-review-results.env\nfi\n# Keep a short tail for the agent prompt\ntail -n 80 /tmp/pr-build.log > /tmp/pr-build-tail.log || true\n"
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -448,9 +459,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_fcd3245069495b34_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9e051f0bbc187182_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_fcd3245069495b34_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_9e051f0bbc187182_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -639,7 +650,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_ad1383bc996f0e61_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_162d9e1a34c8c493_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -681,7 +692,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ad1383bc996f0e61_EOF
+          GH_AW_MCP_CONFIG_162d9e1a34c8c493_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/pr-review-agent.md
+++ b/.github/workflows/pr-review-agent.md
@@ -30,6 +30,26 @@ tools:
 safe-outputs:
   add-comment: {}
 
+steps:
+  - name: Set up Go
+    uses: actions/setup-go@v6
+    with:
+      go-version-file: './go.mod'
+      cache: true
+
+  - name: Build provider
+    id: build
+    continue-on-error: true
+    run: |
+      set -o pipefail
+      if make build 2>&1 | tee /tmp/pr-build.log; then
+        echo "BUILD_RESULT=pass" > /tmp/pr-review-results.env
+      else
+        echo "BUILD_RESULT=fail" > /tmp/pr-review-results.env
+      fi
+      # Keep a short tail for the agent prompt
+      tail -n 80 /tmp/pr-build.log > /tmp/pr-build-tail.log || true
+
 source: local
 engine: copilot
 ---
@@ -57,8 +77,15 @@ If `resourceDefinition.json` is modified:
 - Comment with a summary table of changes
 
 ### 4. Build verification
-- Run `make build` to verify the PR compiles and tests pass
-- If failures, comment with the error output
+- The `Build provider` pre-agent step has already run `make build` on the runner
+  (where Go from `go.mod` is installed). Read the result from
+  `/tmp/pr-review-results.env` — it contains `BUILD_RESULT=pass` or
+  `BUILD_RESULT=fail`.
+- If `BUILD_RESULT=fail`, include the tail of `/tmp/pr-build-tail.log` (last
+  80 lines) in the comment as a fenced code block.
+- Do NOT attempt to run `make build` or `go build` from inside the agent
+  sandbox — the agent container does not have the Go toolchain. The pre-agent
+  step is the source of truth.
 
 ## Comment format
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Run Microsoft Security DevOps
       uses: microsoft/security-devops-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Go version updated from 1.24.4 to 1.25.0
   - Aligned `e2e/go.mod` dependencies (`terraform-exec` v0.25.0, `terraform-json` v0.27.2, `go-cty` v1.17.0)
   - Impact: Low -- dependency update only, no breaking changes
+- **Dev Environment**: Bumped `.devcontainer/devcontainer.json` Go feature from `1.24.4` to `1.25.0` to match `go.mod` (`go 1.25.0`). Previous pin would have failed `go build` inside the dev container.
+- **Documentation**: Updated `.github/CONTRIBUTING.md` prerequisite from `Go 1.24.4+` to `Go 1.25.0+` to match `go.mod`.
+
+### Security
+- **CI/Automation**: SHA-pinned `actions/checkout` and `actions/setup-go` in hand-authored workflows (`codeql.yml`, `copilot-setup-steps.yml`, `e2e.yml`, `go.yml`, `security.yml`) to match the SHA-pinning posture of the gh-aw-managed agentic lock files. Pinned `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) and `actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c` (v6.4.0). Mitigates tag-mutability risk (CWE-829).
+
+### Fixed
+- **CI/Automation**: Added a pre-agent `Set up Go` + `Build provider` step block to `pr-review-agent.md` so the PR review agent can verify `make build` against the repo's Go version (`go.mod` → `1.25.0`). Previously the agent reported "Build passes ⚠️ Unverified — Go toolchain unavailable in sandbox" because the gh-aw agent container (`ghcr.io/github/gh-aw-firewall/agent`) does not ship a Go toolchain. The build now runs on the host runner (where `setup-go` populates the tool cache) and the agent reads `BUILD_RESULT` and a 80-line log tail from `/tmp/`. **Requires recompiling** with `gh aw compile pr-review-agent` to regenerate `pr-review-agent.lock.yml`.
 - **CI/Automation**: Recompiled all 10 GitHub Agentic Workflow lock files with `gh aw` v0.72.1 (previously v0.61.0)
   - Generated missing `.lock.yml` files for `contributor-welcome`, `issue-to-pr-agent`, `nightly-regression`, `pr-review-agent`, `release-validation`, and `weekly-azure-sync`
 - **CI/Automation**: Migrated agentic workflows to current gh-aw schema


### PR DESCRIPTION
## Summary

Tooling-consistency follow-up to #459. Three related fixes:

### 1. Go version drift
- `go.mod` / `e2e/go.mod` require Go 1.25.0, but [.devcontainer/devcontainer.json](.devcontainer/devcontainer.json) still pinned the Go feature to **1.24.4** — \`go build\` inside the dev container would have failed. Bumped to 1.25.0.
- [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) prerequisite updated \`Go 1.24.4+\` → \`Go 1.25.0+\`.

### 2. SHA-pin hand-authored workflows
The gh-aw-managed agentic lock files SHA-pin every action, but the hand-authored workflows still used floating \`@v6\` tags. Pinned to match:
- \`actions/checkout@v6\` → \`@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2\`
- \`actions/setup-go@v6\` → \`@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0\`

Files: [codeql.yml](.github/workflows/codeql.yml), [copilot-setup-steps.yml](.github/workflows/copilot-setup-steps.yml), [e2e.yml](.github/workflows/e2e.yml), [go.yml](.github/workflows/go.yml), [security.yml](.github/workflows/security.yml). Mitigates CWE-829 (untrusted-tag pinning).

### 3. Install Go in the pr-review-agent sandbox
The recompiled PR review agent reported:
> Build passes ⚠️ Unverified — Go toolchain unavailable in sandbox

Root cause: the gh-aw firewall agent container (\`ghcr.io/github/gh-aw-firewall/agent:0.25.41\`) ships no Go toolchain.

Fix in [pr-review-agent.md](.github/workflows/pr-review-agent.md): added a pre-agent \`steps:\` block that runs \`actions/setup-go\` + \`make build\` on the host runner, writes \`BUILD_RESULT=pass|fail\` and an 80-line log tail to \`/tmp/\`. The agent now reads the result instead of trying to invoke Go inside its sandbox. Matches the pattern used by [nightly-regression.md](.github/workflows/nightly-regression.md).

Recompiled with \`gh-aw v0.72.1\` (same compiler as #459). [.github/aw/actions-lock.json](.github/aw/actions-lock.json) was auto-updated to include \`actions/setup-go@v6\`.

## Files changed
- \`.devcontainer/devcontainer.json\` — Go 1.24.4 → 1.25.0
- \`.github/CONTRIBUTING.md\` — Go 1.24.4+ → 1.25.0+
- \`.github/aw/actions-lock.json\` — auto-populated (setup-go)
- \`.github/workflows/{codeql,copilot-setup-steps,e2e,go,security}.yml\` — SHA-pin
- \`.github/workflows/pr-review-agent.md\` + \`pr-review-agent.lock.yml\` — Go in sandbox
- \`CHANGELOG.md\` — \`[Unreleased]\` Changed/Security/Fixed entries

## Validation
- No \`.go\` source files touched; \`make build\` runs locally (\`go version go1.26.3\`).
- gh-aw recompile clean: \`✓ Compiled 1 workflow(s): 0 error(s), 0 warning(s)\`.
- No remaining floating \`actions/*@v6\` pins in hand-authored workflows.